### PR TITLE
Pablos patch

### DIFF
--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -16,7 +16,7 @@ in
         "http://web.archive.org/web/20220212002603/http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-1.0.0-1lsb3.2.src.rpm"
       ];
 
-      sha256 = "46adef0d526894507e622d8e8896d3ecbadffb284931d7dbc46c0662a50dcd8d";
+      hash = "sha256-Rq3vDVJolFB+Yi2OiJbT7Lrf+yhJMdfbxGwGYqUNzY0=";
     };
 
     nativeBuildInputs = [ rpmextract autoreconfHook file ];

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -73,6 +73,6 @@ in
       '';
       license = with licenses; [ lgpl21 epson ];
       platforms = platforms.linux;
-      maintainers = [ maintainers.nphilou ];
+      maintainers = with maintainers; [ nphilou ];
     };
   }

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -12,7 +12,7 @@ in
     src = fetchurl {
       # NOTE: Don't forget to update the webarchive link too!
       urls = [
-        "http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-1.0.0-1lsb3.2.src.rpm"
+        "http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-${version}-1lsb3.2.src.rpm"
         "http://web.archive.org/web/20220212002603/http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-1.0.0-1lsb3.2.src.rpm"
       ];
 

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -4,7 +4,6 @@
     version = "1.0.0";
     filterVersion = "1.0.0";
     pname = "epson-201202w";
-    inherit version;
 
     src = fetchurl {
       # NOTE: Don't forget to update the webarchive link too!

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, rpmextract, autoreconfHook, file, libjpeg, cups }:
 
-let
-  version = "1.0.0";
-  filterVersion = "1.0.0";
-in
-  stdenv.mkDerivation {
+  stdenv.mkDerivation rec {
+  
+    version = "1.0.0";
+  
+    filterVersion = "1.0.0";
 
     pname = "epson-201202w";
     inherit version;

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -1,11 +1,8 @@
 { lib, stdenv, fetchurl, rpmextract, autoreconfHook, file, libjpeg, cups }:
 
   stdenv.mkDerivation rec {
-  
     version = "1.0.0";
-  
     filterVersion = "1.0.0";
-
     pname = "epson-201202w";
     inherit version;
 

--- a/pkgs/misc/drivers/epson-201202w/default.nix
+++ b/pkgs/misc/drivers/epson-201202w/default.nix
@@ -1,0 +1,78 @@
+{ lib, stdenv, fetchurl, rpmextract, autoreconfHook, file, libjpeg, cups }:
+
+let
+  version = "1.0.0";
+  filterVersion = "1.0.0";
+in
+  stdenv.mkDerivation {
+
+    pname = "epson-201202w";
+    inherit version;
+
+    src = fetchurl {
+      # NOTE: Don't forget to update the webarchive link too!
+      urls = [
+        "http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-1.0.0-1lsb3.2.src.rpm"
+        "http://web.archive.org/web/20220212002603/http://download.ebz.epson.net/dsc/f/01/00/01/77/09/d9c270238d35e885c89b4686665b383be8308fb8/epson-inkjet-printer-201202w-1.0.0-1lsb3.2.src.rpm"
+      ];
+
+      sha256 = "46adef0d526894507e622d8e8896d3ecbadffb284931d7dbc46c0662a50dcd8d";
+    };
+
+    nativeBuildInputs = [ rpmextract autoreconfHook file ];
+
+    buildInputs = [ libjpeg cups ];
+
+    unpackPhase = ''
+      rpmextract $src
+      tar -zxf epson-inkjet-printer-201202w-${version}.tar.gz
+      tar -zxf epson-inkjet-printer-filter-${filterVersion}.tar.gz
+      for ppd in epson-inkjet-printer-201202w-${version}/ppds/*; do
+        substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-201202w" "$out"
+        substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
+      done
+      cd epson-inkjet-printer-filter-${filterVersion}
+    '';
+
+    preConfigure = ''
+      chmod +x configure
+      export LDFLAGS="$LDFLAGS -Wl,--no-as-needed"
+    '';
+
+    postInstall = ''
+      cd ../epson-inkjet-printer-201202w-${version}
+      cp -a lib64 resource watermark $out
+      mkdir -p $out/share/cups/model/epson-inkjet-printer-201202w
+      cp -a ppds $out/share/cups/model/epson-inkjet-printer-201202w/
+      cp -a Manual.txt $out/doc/
+      cp -a README $out/doc/README.driver
+    '';
+
+    meta = with lib; {
+      homepage = "https://www.openprinting.org/driver/epson-201202w";
+      description = "Epson printer driver (XP-102 103 Series, XP-202 203 206 Series, XP-205 207 Series, XP-30 33 Series)";
+      longDescription = ''
+        This software is a filter program used with the Common UNIX Printing
+        System (CUPS) under Linux. It supplies high quality printing with
+        Seiko Epson Color Ink Jet Printers.
+        List of printers supported by this package:
+          Epson XP-102 Series
+          Epson XP-103 Series
+          Epson XP-202 Series
+          Epson XP-203 Series
+          Epson XP-206 Series
+          Epson XP-205 Series
+          Epson XP-207 Series
+          Epson XP-30 Series
+          Epson XP-33 Series
+        To use the driver adjust your configuration.nix file:
+          services.printing = {
+            enable = true;
+            drivers = [ pkgs.epson-201202w ];
+          };
+      '';
+      license = with licenses; [ lgpl21 epson ];
+      platforms = platforms.linux;
+      maintainers = [ maintainers.nphilou ];
+    };
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32816,6 +32816,8 @@ with pkgs;
 
   epson_201207w = callPackage ../misc/drivers/epson_201207w { };
 
+  epson-201202w = callPackage ../misc/drivers/epson-201202w { };
+
   epson-201401w = callPackage ../misc/drivers/epson-201401w { };
 
   epson-201106w = callPackage ../misc/drivers/epson-201106w { };


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
